### PR TITLE
「お問い合せフォーム」と「個人情報保護方針」の2つのページを修正

### DIFF
--- a/contactUs.html
+++ b/contactUs.html
@@ -88,151 +88,154 @@
 
   <!-- contact section -->
   <section class="contact-section layout_padding">
-    <div class="container">
-      <div class="heading_container heading_center">
-        <h2 class="text-center pb-2">お問い <span>合わせ</span></h2>
+    <div class="contactUs_container">
+      <div class="container">
+        <div class="heading_container heading_center pb-3">
+          <h2>お問い <span>合わせ</span></h2>
+        </div>
+        <form action="mail.php" method="POST">
+          <div class="card bg-color mt-10">
+            <div class="card-body">
+              <div class="row pb-3 align-items-center col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">お名前（漢字）<span class="text-danger">※</span></label>
+                <div class="row col-auto">
+                  <div class="col-auto">
+                    <div data-mdb-input-init class="form-outline">
+                      <label class="form-label" for="お名前姓">姓</label>
+                      <input type="text" name="お名前姓" class="form-control" />
+                    </div>
+                  </div>
+
+                  <div class="col-auto">
+                    <div data-mdb-input-init class="form-outline">
+                      <label class="form-label" for="お名前名">名</label>
+                      <input type="text" name="お名前名" class="form-control" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row pb-3 align-items-center col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">お名前（かな）<span class="text-danger">※</span></label>
+                <div class="row col-auto">
+                  <div class="col-auto">
+                    <div data-mdb-input-init class="form-outline">
+                      <label class="form-label" for="ふりがな姓">姓</label>
+                      <input type="text" name="ふりがな姓" class="form-control" />
+                    </div>
+                  </div>
+                  <div class="col-auto">
+                    <div data-mdb-input-init class="form-outline">
+                      <label class="form-label" for="ふりがな名">名</label>
+                      <input type="text" name="ふりがな名" class="form-control" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row align-items-center pb-3 col-auto">
+                <label class="col-sm-5 col-form-label" for="会社学校名">会社・学校名</label>
+                <div class="col-auto">
+                  <input type="text" name="会社学校名" size="48" class="form-control">
+                </div>
+              </div>
+              <div class="row align-items-center pb-3 col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap" for="部署役職名">部署・役職名</label>
+                <div class="col-auto">
+                  <input type="text" name="部署役職名" size="48" class="form-control">
+                </div>
+              </div>
+
+              <div class="row align-items-center pb-3 col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">住所 <span class="text-danger">※</span></label>
+                <div class="col-auto">
+                  <textarea name="住所" cols="48" rows="4" class="form-control"></textarea>
+                </div>
+              </div>
+              <div class="row align-items-center pb-3 col-auto">
+                <div class="col-sm-5">
+                  <label class="mb-0 col-form-label text-nowrap">メールアドレス <span class="text-danger">※</span></label>
+                </div>
+                <div class="col-auto">
+                  <input type="email" name="メールアドレス" size="48" class="form-control" />
+                </div>
+              </div>
+              <div class="row align-items-center pb-3 col-auto">
+                <div class="col-sm-5">
+                  <label class="mb-0 col-form-label text-nowrap">メールアドレス(確認用) <span class="text-danger">※</span></label>
+                </div>
+                <div class="col-auto">
+                  <input type="email" name="メールアドレス確認用" size="48" class="form-control" />
+                </div>
+              </div>
+              <div class="row g-2 align-items-center pb-3 col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">日中連絡先</label>
+                <div class="col-auto">
+                  <input type="text" name="日中連絡先" size="48" class="form-control">
+                </div>
+              </div>
+              <div class="row align-items-center pb-3 col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">問い合わせ種別 <span class="text-danger">※</span></label>
+                <div class="col-auto">
+                  <select class="form-control form-select" name="問い合わせ種別">
+                    <option value="貿易関係">貿易関係</option>
+                    <option value="お仕事を探しの方">お仕事を探しの方</option>
+                    <option value="企業のご担当の方">企業のご担当の方</option>
+                    <option value="その他問い合わせ">その他問い合わせ</option>
+                  </select>
+                </div>
+              </div>
+              <div class="row align-items-center pb-3 col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">ご相談・お問い合わせ内容 <span
+                    class="text-danger">※</span></label>
+                <div class="col-auto">
+                  <textarea name="お問い合わせ詳細" cols="48" rows="10" class="form-control"></textarea>
+                </div>
+              </div>
+              <div class="row align-items-center col-auto">
+                <label class="col-sm-5 col-form-label text-nowrap">豊雨を知ったきっかけ</label>
+                <div class="col-auto">
+                  <select class="form-control form-select" name="豊雨を知ったきっかけ">
+                    <option value="豊雨からの営業">豊雨からの営業</option>
+                    <option value="DMなど">DMなど</option>
+                    <option value="豊雨利用者・知人の紹介">豊雨利用者・知人の紹介</option>
+                    <option value="捜索エンジン">捜索エンジン</option>
+                    <option value="その他">その他</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="contact-agree" class="card bg-color mt-4 mb-3">
+            <div class="card-body">
+              <h4 class="text-center"><b>◆プライバシーポリシー</b></h4>
+              <p class="pb-2">
+                ご入力いただいきました個人情報は、当社の個人情報保護方針のもとで、厳重なセキュリティ対策を施し、適正な個人情報の管理を実施いたします。
+                </br>なお、ご入力いただきました個人情報につきましては、以下の目的で利用いたします。</p>
+              <p class="pb-1 mt-0">当社サービスに関する情報の提供・収集のため</p>
+              <p class="pb-1 mt-0">当社サービスに関する情報、セミナー、その他情報のご案内のため</p>
+              <p class="mt-0">当社のマーケティング活動における顧客分析・統計調査</p>
+              <p class="pb-1">
+                当社では、個人情報を上記に記載している利用目的の範囲内で委託先に開示する場合および法令に基づいて提供する場合を除き、あらかじめご本人から同意を得ることなく第三者に開示または提供することはありません。
+                なお、委託先に個人情報を開示する場合には、 当社が定める安全対策基準を満たす事業者を選定し、適切な管理・監督をおこないます。
+                ご登録いただく情報につきましては、皆様の自由なご判断に基づいて おこなっていただいておりますが、必要な情報をご入力いただけない場合は、
+                当社サービスに関する情報等が提供できない場合がございますのでご了承ください。
+              </p>
+              <p class="pb-2">
+                当社の個人情報の取扱いに関する苦情、お客様ご本人の情報についての開示・訂正・削除のご依頼につきましては、
+                <a href="pri.html" target="_blank">「個人情報保護方針」</a>をご覧ください。
+              </p>
+            </div>
+          </div>
+          <p class="text-center py-2"><input type="checkbox" name="agree" id="agree" onchange="ContactAgreement(this)">
+            プライバシーポリシーに同意する</p>
+          <p class="text-center">
+            <input type="submit" value="内容を確認する" class="btn btn-outline-primary text-center" id="contact-confirm"
+              disabled>
+          </p>
+        </form>
       </div>
-      <form action="mail.php" method="POST">
-        <div class="card bg-color mt-10">
-          <div class="card-body">
-            <div class="row pb-3 align-items-center col-auto">
-              <label class="col-sm-3 col-form-label">お名前（漢字）<span class="text-danger">※</span></label>
-              <div class="row col-auto">
-                <div class="col-auto">
-                  <div data-mdb-input-init class="form-outline">
-                    <label class="form-label" for="お名前姓">姓</label>
-                    <input type="text" name="お名前姓" class="form-control" />
-                  </div>
-                </div>
-
-                <div class="col-auto">
-                  <div data-mdb-input-init class="form-outline">
-                    <label class="form-label" for="お名前名">名</label>
-                    <input type="text" name="お名前名" class="form-control" />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="row pb-3 align-items-center col-auto">
-              <label class="col-sm-3 col-form-label">お名前（かな）<span class="text-danger">※</span></label>
-              <div class="row col-auto">
-                <div class="col-auto">
-                  <div data-mdb-input-init class="form-outline">
-                    <label class="form-label" for="ふりがな姓">姓</label>
-                    <input type="text" name="ふりがな姓" class="form-control" />
-                  </div>
-                </div>
-                <div class="col-auto">
-                  <div data-mdb-input-init class="form-outline">
-                    <label class="form-label" for="ふりがな名">名</label>
-                    <input type="text" name="ふりがな名" class="form-control" />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="row align-items-center pb-3 col-auto">
-              <label class="col-sm-3 col-form-label" for="会社学校名">会社・学校名</label>
-              <div class="col-auto">
-                <input type="text" name="会社学校名" size="48" class="form-control">
-              </div>
-            </div>
-            <div class="row align-items-center pb-3 col-auto">
-              <label class="col-sm-3 col-form-label" for="部署役職名">部署・役職名</label>
-              <div class="col-auto">
-                <input type="text" name="部署役職名" size="48" class="form-control">
-              </div>
-            </div>
-
-            <div class="row align-items-center pb-3 col-auto">
-              <label class="col-sm-3 col-form-label">住所</label>
-              <div class="col-auto">
-                <textarea name="住所" cols="48" rows="4" class="form-control"></textarea>
-              </div>
-            </div>
-            <div class="row align-items-center pb-3 col-auto">
-              <div class="col-md-3">
-                <h6 class="mb-0">メールアドレス<span class="text-danger">※</span></h6>
-              </div>
-              <div class="col-auto">
-                <input type="email" name="メールアドレス" size="48" class="form-control" />
-              </div>
-            </div>
-            <div class="row align-items-center pb-3 col-auto ">
-              <div class="col-sm-3">
-                <h6 class="mb-0">メールアドレス(確認用)<span class="text-danger">※</span></h6>
-              </div>
-              <div class="col-auto">
-                <input type="email" name="メールアドレス確認用" size="48" class="form-control" />
-              </div>
-            </div>
-            <div class="row g-2 align-items-center pb-3 col-auto">
-              <label class="col-sm-3 col-form-label">日中連絡先</label>
-              <div class="col-auto">
-                <input type="text" name="日中連絡先" size="48" class="form-control">
-              </div>
-            </div>
-            <div class="row align-items-center pb-3 col-auto">
-              <label class="col-sm-3 col-form-label">問い合わせ種別<span class="text-danger">※</span></label>
-              <div class="col-auto">
-                <select class="form-control form-select" name="問い合わせ種別">
-                  <option value="貿易関係">貿易関係</option>
-                  <option value="お仕事を探しの方">お仕事を探しの方</option>
-                  <option value="企業のご担当の方">企業のご担当の方</option>
-                  <option value="その他問い合わせ">その他問い合わせ</option>
-                </select>
-              </div>
-            </div>
-            <div class="row align-items-center pb-3 col-auto">
-              <label class="col-sm-3 col-form-label">ご相談・お問い合わせ内容<span class="text-danger">※</span></label>
-              <div class="col-auto">
-                <textarea name="お問い合わせ詳細" cols="48" rows="10" class="form-control"></textarea>
-              </div>
-            </div>
-            <div class="row align-items-center col-auto">
-              <label class="col-sm-3 col-form-label">豊雨を知ったきっかけ</label>
-              <div class="col-auto">
-                <select class="form-control form-select" name="豊雨を知ったきっかけ">
-                  <option value="豊雨からの営業">豊雨からの営業</option>
-                  <option value="DMなど">DMなど</option>
-                  <option value="豊雨利用者・知人の紹介">豊雨利用者・知人の紹介</option>
-                  <option value="捜索エンジン">捜索エンジン</option>
-                  <option value="その他">その他</option>
-                </select>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div id="contact-agree" class="card bg-color mt-4 mb-3">
-          <div class="card-body">
-            <h4 class="text-center"><b>◆プライバシーポリシー</b></h4>
-            <p class="pb-2">
-              ご入力いただいきました個人情報は、当社の個人情報保護方針のもとで、厳重なセキュリティ対策を施し、適正な個人情報の管理を実施いたします。
-              </br>なお、ご入力いただきました個人情報につきましては、以下の目的で利用いたします。</p>
-            <p class="pb-1 mt-0">当社サービスに関する情報の提供・収集のため</p>
-            <p class="pb-1 mt-0">当社サービスに関する情報、セミナー、その他情報のご案内のため</p>
-            <p class="mt-0">当社のマーケティング活動における顧客分析・統計調査</p>
-            <p class="pb-1">
-              当社では、個人情報を上記に記載している利用目的の範囲内で委託先に開示する場合および法令に基づいて提供する場合を除き、あらかじめご本人から同意を得ることなく第三者に開示または提供することはありません。
-              なお、委託先に個人情報を開示する場合には、 当社が定める安全対策基準を満たす事業者を選定し、適切な管理・監督をおこないます。
-              ご登録いただく情報につきましては、皆様の自由なご判断に基づいて おこなっていただいておりますが、必要な情報をご入力いただけない場合は、
-              当社サービスに関する情報等が提供できない場合がございますのでご了承ください。
-            </p>
-            <p class="pb-2">
-              当社の個人情報の取扱いに関する苦情、お客様ご本人の情報についての開示・訂正・削除のご依頼につきましては、<a href="pri.html">「個人情報保護方針」</a>をご覧ください。
-            </p>
-          </div>
-        </div>
-        <p class="text-center py-2"><input type="checkbox" name="agree" id="agree" onchange="ContactAgreement(this)">
-          プライバシーポリシーに同意する</p>
-        <p class="text-center">
-          <input type="submit" value="内容を確認する" class="btn btn-outline-primary text-center" id="contact-confirm"
-            disabled>
-        </p>
-      </form>
     </div>
   </section>
   <!-- end contact section -->
-
 
   <!-- info section -->
 

--- a/pri.html
+++ b/pri.html
@@ -90,366 +90,366 @@
 
     <!-- contact section -->
     <section class="contact-section layout_padding">
-        <div class="container">
-            <div class="heading_container heading_center">
-                <h2 class="text-center pb-2">◆個人情報保護 <span>方針</span></h2>
-            </div>
-            <div class="pb-5">
-                <h6 class="lead">・個人情報保護方針</h6>
-                <div class="pb-10">
-                    <div class="d-flex pb-2">
-                        <div>1.</div>
-                        <div>豊雨株式会社は事業活動を行う上で、個人情報を適切に取り扱うことは社会的責務であると考えています。</br>当社では、この責務を全うするために、以下の取り組みを実施します。</div>
-                    </div>
+        <div class="pri_container">
+            <div class="container">
+                <div class="heading_container heading_center">
+                    <h2 class="text-center pb-2">◆個人情報保護 <span>方針</span></h2>
+                </div>
+                <div class="pb-5">
+                    <h6 class="lead">・個人情報保護方針</h6>
+                    <div class="pb-10">
+                        <div class="d-flex pb-2">
+                            <div>1.</div>
+                            <div>豊雨株式会社は事業活動を行う上で、個人情報を適切に取り扱うことは社会的責務であると考えています。</br>当社では、この責務を全うするために、以下の取り組みを実施します。
+                            </div>
+                        </div>
 
-                    <div class="lead pb-2"><b>個人情報の取得、利用及び提供について</b></div>
-                    <div class="d-flex pb-2">
-                        <div>2.</div>
+                        <div class="lead pb-2"><b>個人情報の取得、利用及び提供について</b></div>
+                        <div class="d-flex pb-2">
+                            <div>2.</div>
+                            <div>
+                                当社の全ての事業で取り扱う個人情報および当社従業員の個人情報について、当社の事業の内容と規模を考慮した、適切な取得、利用及び提供を行い、特定した利用目的の達成に必要な範囲を超えた個人情報の取扱（以下、「目的外利用」という）を行うことはありません。</br>目的外利用を行う場合には、予めご本人の同意を得るものとし、同意を得ず目的外利用を行わないための措置を講じます。
+                            </div>
+                        </div>
                         <div>
-                            当社の全ての事業で取り扱う個人情報および当社従業員の個人情報について、当社の事業の内容と規模を考慮した、適切な取得、利用及び提供を行い、特定した利用目的の達成に必要な範囲を超えた個人情報の取扱（以下、「目的外利用」という）を行うことはありません。</br>目的外利用を行う場合には、予めご本人の同意を得るものとし、同意を得ず目的外利用を行わないための措置を講じます。
+                            <div class="lead pb-1">３．取り組み</div>
+                            <div class="pl-5 pb-3">個人情報への不正アクセスや、個人情報の漏えい、紛失、破壊、改ざん等に対して、合理的な防止並びに是正措置を取ります。</div>
+                            <ul class="list-unstyled">
+                                <li class="pb-2">
+                                    <div class="pb-1">
+                                        <b>
+                                            <div class="d-flex">
+                                                <div>（１）</div>
+                                                <div>個人情報の取得、利用および提供について</div>
+                                            </div>
+                                        </b>
+                                    </div>
+                                    <div class="pl-5">
+                                        当社が使用するすべての個人情報について、適切な取得、利用および提供を行い、特定した利用目的の達成に必要な範囲を超えて個人情報を取り扱わないこと、
+                                        およびそのための措置を講じるものとします。</br>その利用目的を超えて個人情報の取り扱いを行う場合には、あらかじめ対象者の同意を得るものとします。</div>
+                                </li>
+                                <li class="pb-2">
+                                    <div class="pb-1">
+                                        <b>
+                                            <div class="d-flex">
+                                                <div>（２）</div>
+                                                <div>個人情報に関する法令や指針、規範について</div>
+                                            </div>
+                                        </b>
+                                    </div>
+                                    <div class="pl-5">個人情報に関する法令・国が定める指針その他の規範を順守します。</div>
+                                </li>
+                                <li class="pb-2">
+                                    <div class="pb-1">
+                                        <b>
+                                            <div class="d-flex">
+                                                <div>（３）</div>
+                                                <div>個人情報の安全管理について</div>
+                                            </div>
+                                        </b>
+                                    </div>
+                                    <div class="pl-5">個人情報への不正アクセスや、個人情報の漏えい、紛失、破壊、改ざん等に対して、合理的な防止ならびに是正措置を講じます。</div>
+                                </li>
+                                <li class="pb-2">
+                                    <div class="pb-1">
+                                        <b>
+                                            <div class="d-flex pb-1">
+                                                <div>（４）</div>
+                                                <div>個人情報の安全管理について</div>
+                                            </div>
+                                        </b>
+                                    </div>
+                                    <div class="pl-5">個人情報に関する苦情および相談には、速やかに対処するものとします。</div>
+                                </li>
+                                <li class="pb-2">
+                                    <div class="pb-1">
+                                        <b>
+                                            <div class="d-flex ">
+                                                <div>（５）</div>
+                                                <div>個人情報保護の取り組み（個人情報保護マネジメントシステム）について</div>
+                                            </div>
+                                        </b>
+                                    </div>
+                                    <div class="pl-5">個人情報の保護を適切に行うため、継続的にその取り組みを見直し、改善するものとします。</div>
+                                </li>
+
+                                <li class="">
+                                    <div class="pb-1">
+                                        <b>
+                                            <div class="d-flex">
+                                                <div>（６）</div>
+                                                <div>個人情報の共同利用について</div>
+                                            </div>
+                                        </b>
+                                    </div>
+                                    <div class="pl-5">提供された個人情報について、より付加価値の高いサービスを提供するため、特定した利用目的のみに、
+                                        当社のグループ会社に限り個人情報を共同で利用させていただきます。また、グループ会社各社においても個人情報の利用目的を超えた利用はしないものとします。</div>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div class="text-right pt-2">
+                            <p class="pb-1 mb-0"><b>豊雨　株式会社</b></p>
+                            <p class="pb-1 mb-0">代表取締役 <span class="lead"><b>浅田 紫瑛</b></span></p>
+                            <p class="mb-0">令和2年12月28日 制定</p>
                         </div>
                     </div>
-                    <div>
-                        <div class="lead pb-1">３．取り組み</div>
-                        <div class="pl-5 pb-3">個人情報への不正アクセスや、個人情報の漏えい、紛失、破壊、改ざん等に対して、合理的な防止並びに是正措置を取ります。</div>
-                        <ul class="list-unstyled">
-                            <li class="pb-2">
-                                <div class="pb-1">
-                                    <b>
-                                        <div class="d-flex">
-                                            <div>（１）</div>
-                                            <div>個人情報の取得、利用および提供について</div>
-                                        </div>
-                                    </b>
-                                </div>
-                                <div class="pl-5">
-                                    当社が使用するすべての個人情報について、適切な取得、利用および提供を行い、特定した利用目的の達成に必要な範囲を超えて個人情報を取り扱わないこと、
-                                    およびそのための措置を講じるものとします。</br>その利用目的を超えて個人情報の取り扱いを行う場合には、あらかじめ対象者の同意を得るものとします。</div>
-                            </li>
-                            <li class="pb-2">
-                                <div class="pb-1">
-                                    <b>
-                                        <div class="d-flex">
-                                            <div>（２）</div>
-                                            <div>個人情報に関する法令や指針、規範について</div>
-                                        </div>
-                                    </b>
-                                </div>
-                                <div class="pl-5">個人情報に関する法令・国が定める指針その他の規範を順守します。</div>
-                            </li>
-                            <li class="pb-2">
-                                <div class="pb-1">
-                                    <b>
-                                        <div class="d-flex">
-                                            <div>（３）</div>
-                                            <div>個人情報の安全管理について</div>
-                                        </div>
-                                    </b>
-                                </div>
-                                <div class="pl-5">個人情報への不正アクセスや、個人情報の漏えい、紛失、破壊、改ざん等に対して、合理的な防止ならびに是正措置を講じます。</div>
-                            </li>
-                            <li class="pb-2">
-                                <div class="pb-1">
-                                    <b>
-                                        <div class="d-flex pb-1">
-                                            <div>（４）</div>
-                                            <div>個人情報の安全管理について</div>
-                                        </div>
-                                    </b>
-                                </div>
-                                <div class="pl-5">個人情報に関する苦情および相談には、速やかに対処するものとします。</div>
-                            </li>
-                            <li class="pb-2">
-                                <div class="pb-1">
-                                    <b>
-                                        <div class="d-flex ">
-                                            <div>（５）</div>
-                                            <div>個人情報保護の取り組み（個人情報保護マネジメントシステム）について</div>
-                                        </div>
-                                    </b>
-                                </div>
-                                <div class="pl-5">個人情報の保護を適切に行うため、継続的にその取り組みを見直し、改善するものとします。</div>
-                            </li>
-
-                            <li class="">
-                                <div class="pb-1">
-                                    <b>
-                                        <div class="d-flex">
-                                            <div>（６）</div>
-                                            <div>個人情報の共同利用について</div>
-                                        </div>
-                                    </b>
-                                </div>
-                                <div class="pl-5">提供された個人情報について、より付加価値の高いサービスを提供するため、特定した利用目的のみに、
-                                    当社のグループ会社に限り個人情報を共同で利用させていただきます。また、グループ会社各社においても個人情報の利用目的を超えた利用はしないものとします。</div>
-                            </li>
-                        </ul>
-                    </div>
-
-                    <div class="text-right pt-2">
-                        <p class="pb-1 mb-0"><b>豊雨　株式会社</b></p>
-                        <p class="pb-1 mb-0">代表取締役 <span class="lead"><b>浅田 紫瑛</b></span></p>
-                        <p class="mb-0">令和2年12月28日 制定</p>
-                    </div>
                 </div>
-            </div>
-            <div>
-                <div class="lead pb-2">個人情報の取り扱いについて</div>
-                <div class="pb-3">
-                    <div class="pb-2">
+                <div>
+                    <div class="lead pb-2">個人情報の取り扱いについて</div>
+                    <div class="pb-3">
+                        <div class="pb-2">
+                            <div>
+                                <b>
+                                    <div class="d-flex pb-2">
+                                        <div>1.</div>
+                                        <div>豊雨株式会社（以下「当社」という。）では以下の目的で個人情報を利用します。</div>
+                                    </div>
+                                </b>
+                            </div>
+                            <ul class="list-unstyled">
+                                <li>
+                                    <div class="d-flex pb-2">
+                                        <div>（１）</div>
+                                        <div>派遣登録、人材派遣、人材紹介など当社サービスを提供するため</div>
+                                    </div>
+                                    <div class="pl-5">
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(ア)</div>
+                                            <div>仕事紹介を目的とした、スキル・経験等の確認</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(イ)</div>
+                                            <div>就業機会の確保</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(ウ)</div>
+                                            <div>求人会社への求職者情報の提供のため</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(エ)</div>
+                                            <div>就業時の労務管理（給与計算・福利厚生提供等）のため（給与振込先の金融機関情報）</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(オ)</div>
+                                            <div>適切な雇用管理（制服貸与などのための身体や靴のサイズ情報）</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(カ)</div>
+                                            <div>当社及びグループ会社のサービスに関する情報及び資料送付のため</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(キ)</div>
+                                            <div>契約の締結、維持管理、契約に基づく通知、請求、支払業務のため</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(ク)</div>
+                                            <div>当社サービスに関するアンケート調査</div>
+                                        </div>
+                                        <div class="d-flex pb-1">
+                                            <div class="pr-1">(ケ)</div>
+                                            <div>ご注文された当社の商品をお届けするうえで必要な業務</div>
+                                        </div>
+                                        <div class="d-flex">
+                                            <div class="pr-1">(コ)</div>
+                                            <div>新商品の案内など、お客様に有益かつ必要と思われる情報の提供</div>
+                                        </div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="pb-2">
+                            <div class="d-flex">
+                                <div class="pr-1">（２）</div>
+                                <div>採用に関する選考、決定のため</div>
+                            </div>
+                        </div>
+                        <div class="pb-2">
+                            <div class="d-flex">
+                                <div class="pr-1">（３）</div>
+                                <div>キャリア形成支援を目的とした教育訓練のため</div>
+                            </div>
+                        </div>
+                        <div class="pb-2">
+                            <div class="d-flex">
+                                <div class="pr-1">（４）</div>
+                                <div>各種お問い合わせへの対応のため</div>
+                            </div>
+                        </div>
+                        <div class="pb-2">
+                            <div class="d-flex">
+                                <div class="pr-1">（５）</div>
+                                <div>当社サービス等のご案内のため</div>
+                            </div>
+                        </div>
                         <div>
+                            <div class="d-flex">
+                                <div class="pr-1">（６）</div>
+                                <div>統計データ作成のため</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="pb-3">
+                        <div class="pb-2">
                             <b>
-                                <div class="d-flex pb-2">
-                                    <div>1.</div>
-                                    <div>豊雨株式会社（以下「当社」という。）では以下の目的で個人情報を利用します。</div>
+                                <div class="d-flex">
+                                    <div>2.</div>
+                                    <div>個人情報を本人の同意なしに第三者へ提供することはありません。
+                                    </div>
                                 </div>
                             </b>
                         </div>
-                        <ul class="list-unstyled">
-                            <li>
-                                <div class="d-flex pb-2">
+                        <div class="pl-3 pb-2">ただし、以下のいずれかに該当するときには提供する場合があります。</div>
+                        <ul class="list-unstyled pl-3">
+                            <li class="pb-1">
+                                <div class="d-flex">
                                     <div>（１）</div>
-                                    <div>派遣登録、人材派遣、人材紹介など当社サービスを提供するため</div>
-                                </div>
-                                <div class="pl-5">
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(ア)</div>
-                                        <div>仕事紹介を目的とした、スキル・経験等の確認</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(イ)</div>
-                                        <div>就業機会の確保</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(ウ)</div>
-                                        <div>求人会社への求職者情報の提供のため</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(エ)</div>
-                                        <div>就業時の労務管理（給与計算・福利厚生提供等）のため（給与振込先の金融機関情報）</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(オ)</div>
-                                        <div>適切な雇用管理（制服貸与などのための身体や靴のサイズ情報）</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(カ)</div>
-                                        <div>当社及びグループ会社のサービスに関する情報及び資料送付のため</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(キ)</div>
-                                        <div>契約の締結、維持管理、契約に基づく通知、請求、支払業務のため</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(ク)</div>
-                                        <div>当社サービスに関するアンケート調査</div>
-                                    </div>
-                                    <div class="d-flex pb-1">
-                                        <div class="pr-1">(ケ)</div>
-                                        <div>ご注文された当社の商品をお届けするうえで必要な業務</div>
-                                    </div>
-                                    <div class="d-flex">
-                                        <div class="pr-1">(コ)</div>
-                                        <div>新商品の案内など、お客様に有益かつ必要と思われる情報の提供</div>
-                                    </div>
+                                    <div>法令に基づく場合</div>
                                 </div>
                             </li>
-                        </ul>
-                    </div>
-                    <div class="pb-2">
-                        <div class="d-flex">
-                            <div class="pr-1">（２）</div>
-                            <div>採用に関する選考、決定のため</div>
-                        </div>
-                    </div>
-                    <div class="pb-2">
-                        <div class="d-flex">
-                            <div class="pr-1">（３）</div>
-                            <div>キャリア形成支援を目的とした教育訓練のため</div>
-                        </div>
-                    </div>
-                    <div class="pb-2">
-                        <div class="d-flex">
-                            <div class="pr-1">（４）</div>
-                            <div>各種お問い合わせへの対応のため</div>
-                        </div>
-                    </div>
-                    <div class="pb-2">
-                        <div class="d-flex">
-                            <div class="pr-1">（５）</div>
-                            <div>当社サービス等のご案内のため</div>
-                        </div>
-                    </div>
-                    <div>
-                        <div class="d-flex">
-                            <div class="pr-1">（６）</div>
-                            <div>統計データ作成のため</div>
-                        </div>
-                    </div>
-                </div>
-                <div class="pb-3">
-                    <div class="pb-2">
-                        <b>
-                            <div class="d-flex">
-                                <div>2.</div>
-                                <div>個人情報を本人の同意なしに第三者へ提供することはありません。
-                                </div>
-                            </div>
-                        </b>
-                    </div>
-                    <div class="pl-3 pb-2">ただし、以下のいずれかに該当するときには提供する場合があります。</div>
-                    <ul class="list-unstyled pl-3">
-                        <li class="pb-1">
-                            <div class="d-flex">
-                                <div>（１）</div>
-                                <div>法令に基づく場合</div>
-                            </div>
-                        </li>
-                        <li class="pb-1">
-                            <div class="d-flex">
-                                <div>（２）</div>
-                                <div>本人の生命、身体又の保護のために必要がある場合であって、本人の同意をとることが困難である場合</div>
-                            </div>
-                        </li>
-                        <li class="pb-1">
-                            <div class="d-flex">
-                                <div>（３）</div>
-                                <div>公衆衛生の向上又は児童の健全な育成推進のために必要である場合で、本人の同意を得ることが困難な場合</div>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="d-flex">
-                                <div>（４）</div>
-                                <div>国の機関若しくは地方公共団体又はその委託を受けた者が法令で定める事務を遂行することに対して協力する必要がある場合であって、
-                                    本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがある場合</div>
-                            </div>
-                        </li>
-                    </ul>
-                </div>
-                <div class="pb-3">
-                    <div class="pb-2">
-                        <b>
-                            <div>3.個人情報を収集する項目には必須項目と任意項目に分かれています。</div>
-                        </b>
-                    </div>
-                    <div class="pl-3">必須項目に不足がある場合には再提出をお願いすることがあります。</br>再提出がない場合には問い合わせ対応等ができない場合がありますのでご了承ください。</div>
-                </div>
-                <div class="pb-3">
-                    <div class="pb-2">
-                        <b>
-                            <div class="d-flex">
-                                <div>4.</div>
-                                <div>
-                                    当社は個人情報の利用目的の達成に必要な範囲内で、当社が定める個人情報保護の観点から一定水準以上であると認めた委託先にデータ処理業務の一部を委託する場合があります。
-                                </div>
-                            </div>
-                        </b>
-                    </div>
-                    <div class="pl-3">この場合、委託先に十分な個人情報の保護水準を義務付け、当社は適切な監督を実施します。</div>
-                </div>
-                <div class="pb-3">
-                    <div>
-                        <b>
-                            <div class="d-flex pb-2">
-                                <div>5.</div>
-                                <div>
-                                    当社ホームページではより便利に利用していただく等のため、クッキー（Cookie）を使用する場合がありますが、クッキーによって個人を特定できる情報を得ることはありません。
-                                </div>
-                            </div>
-                        </b>
-                    </div>
-                </div>
-                <div class="pb-3">
-                    <div>
-                        <b>
-                            <div class="d-flex pb-2">
-                                <div>6.</div>
-                                <div>安全管理措置について</div>
-                            </div>
-                        </b>
-                    </div>
-                    <div class="pl-3">当社は個人情報の不正アクセスや個人情報の漏えい、紛失、破棄、改ざん等に対して、合理的な防止ならびに是正措置を講じます。 </div>
-                </div>
-                <div class="pb-3">
-                    <div>
-                        <b>
-                            <div class="d-flex pb-2">
-                                <div>7.</div>
-                                <div>従業員の監督について</div>
-                            </div>
-                        </b>
-                    </div>
-                    <div class="pl-3">当社は個人情報の安全管理のために、従業員に対する必要かつ適切な監督、ならびに定期的に適切な教育を実施します。</div>
-                </div>
-                <div class="pb-3">
-                    <div>
-                        <b>
-                            <div class="d-flex pb-2">
-                                <div>8.</div>
-                                <div>個人情報を提供されることの任意性について</div>
-                            </div>
-                        </b>
-                    </div>
-                    <div class="pl-3">当社に個人情報・特定個人情報を提供されるかどうかは本人の任意によるものです。
-                        </br>ただし、必要な項目をいただけない場合、当社からの各サービスなどが適切な状態で提供できない場合があります。</div>
-                </div>
-                <div class="pb-3">
-                    <div>
-                        <b>
-                            <div class="d-flex pb-2">
-                                <div>9.</div>
-                                <div>個人情報の開示等の請求に応じる手続きについて</div>
-                            </div>
-                        </b>
-                    </div>
-                    <div class="pl-2">
-                        <ul class="list-unstyled">
-                            <li>
-                                <div class="d-flex pb-2">
-                                    <div>（１）</div>
-                                    <div>
-                                        当社が開示・訂正・追加・削除の権限を有する個人情報・特定個人情報に対する本人の権利として、利用目的の通知、開示、内容の訂正、追加又は削除、利用の停止、消去及び第三者への提供の停止の請求を行うことができます。ご本人が容易かつ的確に開示等の請求をすることができるよう、保有する個人情報の提供その他ご本人の利便を考慮した適切な措置を実施いたします。
-                                    </div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="d-flex pb-2">
+                            <li class="pb-1">
+                                <div class="d-flex">
                                     <div>（２）</div>
-                                    <div>
-                                        請求いただく場合は、当社個人情報保護相談窓口担当者までご連絡してください。電話にて本人確認を行った上で回答させていただき
-                                        ます。本人確認を行った書類は、当社の規定に従って破棄いたします。 </div>
+                                    <div>本人の生命、身体又の保護のために必要がある場合であって、本人の同意をとることが困難である場合</div>
+                                </div>
+                            </li>
+                            <li class="pb-1">
+                                <div class="d-flex">
+                                    <div>（３）</div>
+                                    <div>公衆衛生の向上又は児童の健全な育成推進のために必要である場合で、本人の同意を得ることが困難な場合</div>
                                 </div>
                             </li>
                             <li>
                                 <div class="d-flex">
-                                    <div>（３）</div>
-                                    <div>利用目的の通知と開示に対応するための手数料は徴収いたしません。</div>
+                                    <div>（４）</div>
+                                    <div>国の機関若しくは地方公共団体又はその委託を受けた者が法令で定める事務を遂行することに対して協力する必要がある場合であって、
+                                        本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがある場合</div>
                                 </div>
                             </li>
                         </ul>
                     </div>
+                    <div class="pb-3">
+                        <div class="pb-2">
+                            <b>
+                                <div>3.個人情報を収集する項目には必須項目と任意項目に分かれています。</div>
+                            </b>
+                        </div>
+                        <div class="pl-3">必須項目に不足がある場合には再提出をお願いすることがあります。</br>再提出がない場合には問い合わせ対応等ができない場合がありますのでご了承ください。
+                        </div>
+                    </div>
+                    <div class="pb-3">
+                        <div class="pb-2">
+                            <b>
+                                <div class="d-flex">
+                                    <div>4.</div>
+                                    <div>
+                                        当社は個人情報の利用目的の達成に必要な範囲内で、当社が定める個人情報保護の観点から一定水準以上であると認めた委託先にデータ処理業務の一部を委託する場合があります。
+                                    </div>
+                                </div>
+                            </b>
+                        </div>
+                        <div class="pl-3">この場合、委託先に十分な個人情報の保護水準を義務付け、当社は適切な監督を実施します。</div>
+                    </div>
+                    <div class="pb-3">
+                        <div>
+                            <b>
+                                <div class="d-flex pb-2">
+                                    <div>5.</div>
+                                    <div>
+                                        当社ホームページではより便利に利用していただく等のため、クッキー（Cookie）を使用する場合がありますが、クッキーによって個人を特定できる情報を得ることはありません。
+                                    </div>
+                                </div>
+                            </b>
+                        </div>
+                    </div>
+                    <div class="pb-3">
+                        <div>
+                            <b>
+                                <div class="d-flex pb-2">
+                                    <div>6.</div>
+                                    <div>安全管理措置について</div>
+                                </div>
+                            </b>
+                        </div>
+                        <div class="pl-3">当社は個人情報の不正アクセスや個人情報の漏えい、紛失、破棄、改ざん等に対して、合理的な防止ならびに是正措置を講じます。 </div>
+                    </div>
+                    <div class="pb-3">
+                        <div>
+                            <b>
+                                <div class="d-flex pb-2">
+                                    <div>7.</div>
+                                    <div>従業員の監督について</div>
+                                </div>
+                            </b>
+                        </div>
+                        <div class="pl-3">当社は個人情報の安全管理のために、従業員に対する必要かつ適切な監督、ならびに定期的に適切な教育を実施します。</div>
+                    </div>
+                    <div class="pb-3">
+                        <div>
+                            <b>
+                                <div class="d-flex pb-2">
+                                    <div>8.</div>
+                                    <div>個人情報を提供されることの任意性について</div>
+                                </div>
+                            </b>
+                        </div>
+                        <div class="pl-3">当社に個人情報・特定個人情報を提供されるかどうかは本人の任意によるものです。
+                            </br>ただし、必要な項目をいただけない場合、当社からの各サービスなどが適切な状態で提供できない場合があります。</div>
+                    </div>
+                    <div class="pb-3">
+                        <div>
+                            <b>
+                                <div class="d-flex pb-2">
+                                    <div>9.</div>
+                                    <div>個人情報の開示等の請求に応じる手続きについて</div>
+                                </div>
+                            </b>
+                        </div>
+                        <div class="pl-2">
+                            <ul class="list-unstyled">
+                                <li>
+                                    <div class="d-flex pb-2">
+                                        <div>（１）</div>
+                                        <div>
+                                            当社が開示・訂正・追加・削除の権限を有する個人情報・特定個人情報に対する本人の権利として、利用目的の通知、開示、内容の訂正、追加又は削除、利用の停止、消去及び第三者への提供の停止の請求を行うことができます。ご本人が容易かつ的確に開示等の請求をすることができるよう、保有する個人情報の提供その他ご本人の利便を考慮した適切な措置を実施いたします。
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="d-flex pb-2">
+                                        <div>（２）</div>
+                                        <div>
+                                            請求いただく場合は、当社個人情報保護相談窓口担当者までご連絡してください。電話にて本人確認を行った上で回答させていただき
+                                            ます。本人確認を行った書類は、当社の規定に従って破棄いたします。 </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="d-flex">
+                                        <div>（３）</div>
+                                        <div>利用目的の通知と開示に対応するための手数料は徴収いたしません。</div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
-            </div>
-            <div class="card text-left bg-color">
-                <div class="card-body">
-                    <h6 class="card-title"><b>【個人情報保護相談窓口】</b></p>
+                <div class="card text-left bg-color">
+                    <div class="card-body">
+                        <div class="card-title"><b>【個人情報保護相談窓口】</b></div>
                         <ul class="list-unstyled">
-                            <li class="pb-2">所在地： <a href="https://maps.app.goo.gl/KAify4Jjo3Dm3ycr7"
+                            <li class="pb-2">所在地： <a href="https://maps.app.goo.gl/KAify4Jjo3Dm3ycr7" target="_blank"
                                     class="text-dark"><i class="fa fa-map-marker" aria-hidden="true"><span>
                                             愛知県名古屋市東区東大曾根町29-11</span></i></a>
                             </li>
                             <li class="pb-2">責任者：営業部課長</li>
-                            <li>お問い合わせ先：052-908-6760（受付時間：09：00～18：00）</li>
+                            <li>お問い合わせ先：<a href="tel:0529086760">052-908-6760</a>（受付時間：09：00～18：00）</li>
                         </ul>
+                    </div>
                 </div>
             </div>
         </div>
-
-
-
     </section>
     <!-- end contact section -->
-
 
     <!-- info section -->
 


### PR DESCRIPTION
フォームのラベル崩れ,containerをそれぞれもう1つずつ追加,タグが別ページで表示できるように修正,電話番号押したらすぐにかかるようにしました。